### PR TITLE
changes to be able to get *working* isolinux result

### DIFF
--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -34,4 +34,4 @@ echo "Copying isolinux.bin to $(realpath ../../bootfiles/isolinux.bin)"
 
 cd ..
 rm -Rf $PKG
-rm $PKGTGZ
+rm -f $PKGTGZ

--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -15,7 +15,7 @@ DL="http://www.kernel.org/pub/linux/utils/boot/syslinux/$PKGTGZ"
 # download, unpack, and patch syslinux
 if [ ! -d $PKG ]; then
 	rm -rf $PKG
-	wget -c "$DL"
+	wget --no-check-certificate -c "$DL"
 	tar -xf $PKGTGZ
 fi
 

--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -24,7 +24,9 @@ cd $PKG
 sed -i -r "s:/boot/syslinux:/$LIVEKITNAME/boot:" core/fs/iso9660/iso9660.c
 sed -i -r "s:/boot/syslinux:/$LIVEKITNAME/boot:" core/fs/lib/loadconfig.c
 
-make
+make \
+	${CC:+CC="$CC"}
+
 cp -p core/isolinux.bin ../../bootfiles/isolinux.bin
 
 echo

--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -2,6 +2,9 @@
 
 # This script will update the file ../bootfiles/isolinux.bin to match
 # your LiveKit name used in ../.config
+# Requires: wget, tar, gzip, make, gcc, nasm, perl, glibc-devel, libuuid-devel (e2fsprogs)
+
+set -e
 
 PKG=syslinux-4.06
 PKGTGZ=$PKG.tar.gz
@@ -10,20 +13,23 @@ DL="http://www.kernel.org/pub/linux/utils/boot/syslinux/$PKGTGZ"
 . ../.config
 
 # download, unpack, and patch syslinux
-wget -c "$DL"
-tar -xf $PKGTGZ
-rm $PKGTGZ
+if [ ! -d $PKG ]; then
+	rm -rf $PKG
+	wget -c "$DL"
+	tar -xf $PKGTGZ
+fi
 
 cd $PKG
 
 sed -i -r "s:/boot/syslinux:/$LIVEKITNAME/boot:" core/fs/iso9660/iso9660.c
 sed -i -r "s:/boot/syslinux:/$LIVEKITNAME/boot:" core/fs/lib/loadconfig.c
 
-make -i
-cp core/isolinux.bin ../../bootfiles/isolinux.bin
+make
+cp -p core/isolinux.bin ../../bootfiles/isolinux.bin
 
 echo
 echo "Copying isolinux.bin to $(realpath ../../bootfiles/isolinux.bin)"
 
 cd ..
 rm -Rf $PKG
+rm $PKGTGZ


### PR DESCRIPTION
i spent quite some time to get the isolinux built, as it failed each time with some missing program or header. so i ended up with this patch, in hope it will be helpful in the future to some other users

it does:
do not remove tarball until build has finished, as the build process is
fragile and dependencies that are needed are listed nowhere, meaning i
have to download several times as appeared some tool or header was
missing

ignoring and hiding errors is bad and evil, instead stop on errors so
user can see error and try to fix it

additionally fill out requirements in comment. really should test for
program existence or headers to be very nice with it