### PR TITLE
Update initramfs_create

### DIFF
--- a/initramfs/initramfs_create
+++ b/initramfs/initramfs_create
@@ -74,7 +74,7 @@ copy_including_deps /$LMK/kernel/drivers/block/loop.*
 copy_including_deps /$LMK/kernel/fs/fuse
 copy_including_deps /$LMK/modules.*
 
-find $INITRAMFS -name "*.ko.gz" | xargs gunzip
+find $INITRAMFS -name "*.ko.gz" -exec gunzip {} \;
 
 # trim modules.order file. Perhaps we could remove it entirely
 MODULEORDER="$(cd "$INITRAMFS/$LMK/"; find -name "*.ko" | sed -r "s:^./::g" | tr "\n" "|" | sed -r "s:[.]:.:g")"


### PR DESCRIPTION
Changing that line got rid of a gzip warning "unexpected end of file", at least for me.