### PR TITLE
decrease tftp-based PXE boot time to ~ 1/3rd

### DIFF
--- a/livekitlib
+++ b/livekitlib
@@ -446,6 +446,18 @@ mount_data_http()
 }
 
 
+# stdin = files to get
+# $1 = server
+# $2 = destination directory
+#
+tftp_mget()
+{
+   while read FNAME; do
+      tftp -b 1486 -g -r "$FNAME" -l "$2/$FNAME" "$1"
+   done
+}
+
+
 # Download data from tftp
 # $1 = target (store downloaded files there)
 #
@@ -472,7 +484,7 @@ download_data_pxe()
       if [ $? -ne 0 ]; then
          echo "Error downloading from http://$SERVER:$PORT, trying TFTP" >&2
          PROTOCOL=tftp
-         tftp -g -r PXEFILELIST -l "$1/PXEFILELIST" $SERVER
+         echo PXEFILELIST | tftp_mget "$SERVER" "$1"
       fi
 
       echo "* Downloading files from the list" >&2
@@ -484,7 +496,7 @@ download_data_pxe()
       else
          JOBS=3
          for i in `seq 0 $((JOBS-1))`; do
-            awk "$i == NR % $JOBS"'{print("* "$0" ...") > "/dev/stderr";system("tftp -b 1486 -g -r "$0" -l '"$1/$LIVEKITNAME/"'"$0" '"$SERVER"'")}' < "$1/PXEFILELIST" &
+            awk "NR % $JOBS == $i {print}" < "$1/PXEFILELIST" | tftp_mget "$SERVER" "$1/$LIVEKITNAME" &
          done
          wait
       fi

--- a/livekitlib
+++ b/livekitlib
@@ -453,6 +453,7 @@ mount_data_http()
 tftp_mget()
 {
    while read FNAME; do
+      echo "* $FNAME ..." >&2
       tftp -b 1486 -g -r "$FNAME" -l "$2/$FNAME" "$1"
    done
 }

--- a/livekitlib
+++ b/livekitlib
@@ -452,7 +452,7 @@ mount_data_http()
 download_data_pxe()
 {
    debug_log "download_data_pxe" "$*"
-   local IP CMD CLIENT SERVER GW MASK PORT PROTOCOL
+   local IP CMD CLIENT SERVER GW MASK PORT PROTOCOL JOBS
 
    mkdir -p "$1/$LIVEKITNAME"
    IP="$(cmdline_value ip)"
@@ -477,14 +477,17 @@ download_data_pxe()
 
       echo "* Downloading files from the list" >&2
 
-      cat "$1/PXEFILELIST" | while read FILE; do
-         if [ "$PROTOCOL" = "http" ]; then
+      if [ "$PROTOCOL" = "http" ]; then
+         cat "$1/PXEFILELIST" | while read FILE; do
             wget -O "$1/$LIVEKITNAME/$FILE" "http://$SERVER:$PORT/$FILE"
-         else
-            echo "* $FILE ..." >&2
-            tftp -g -r $FILE -l "$1/$LIVEKITNAME/$FILE" $SERVER
-         fi
-      done
+         done
+      else
+         JOBS=3
+         for i in `seq 0 $((JOBS-1))`; do
+            awk "$i == NR % $JOBS"'{print("* "$0" ...") > "/dev/stderr";system("tftp -b 1486 -g -r "$0" -l '"$1/$LIVEKITNAME/"'"$0" '"$SERVER"'")}' < "$1/PXEFILELIST" &
+         done
+         wait
+      fi
    done
 
    echo "$1/$LIVEKITNAME"


### PR DESCRIPTION
At first I tried to just increase tftp transfer blocksize (tftp -b 1486), which speed things a bit. But biggest decrease in boot time is provided by parallel download. Tested with dnsmasq on my OpenWRT router.