### PR TITLE
script that generates boot logo

### DIFF
--- a/README
+++ b/README
@@ -20,6 +20,7 @@ Note:
   Your kernel must support squashfs and aufs. Debian Jessie's kernel does.
 
 * You may also wish to replace boot graphics in ./bootfiles/bootlogo.png
+  (one options is to modify and run the ./tools/bootlogo.update script) 
   and reorganize isolinux.cfg to fit your needs (when editing the file,
   keep all paths in /boot/, it will be rellocated during LiveKit creation)
 
@@ -34,12 +35,6 @@ Note:
   it will update ./bootfiles/isolinux.bin automatically by downloading
   isolinux sources, patching them using your actual LIVEKITNAME and
   recompiling. This step is not needed if you plan to boot from USB only.
-
-* A default startup image has been provided in ./bootfiles/bootlogo.png,
-  but you will probably want to replace it. There is a script that can
-  generate a new image within ./tools/ called bootlogo.update ...
-  it will update ./bootfiles/bootlogo.png with an image that lists the
-  versions of installed packages. Please modify the script as needed.
 
 * If you have tmpfs mounted on /tmp, make sure you have enough RAM
   since LiveKit will store lots of data there. If you are low on RAM,

--- a/README
+++ b/README
@@ -35,6 +35,12 @@ Note:
   isolinux sources, patching them using your actual LIVEKITNAME and
   recompiling. This step is not needed if you plan to boot from USB only.
 
+* A default startup image has been provided in ./bootfiles/bootlogo.png,
+  but you will probably want to replace it. There is a script that can
+  generate a new image within ./tools/ called bootlogo.update ...
+  it will update ./bootfiles/bootlogo.png with an image that lists the
+  versions of installed packages. Please modify the script as needed.
+
 * If you have tmpfs mounted on /tmp, make sure you have enough RAM
   since LiveKit will store lots of data there. If you are low on RAM,
   make sure /tmp is a regular on-disk directory.

--- a/tools/bootlogo.update
+++ b/tools/bootlogo.update
@@ -1,0 +1,46 @@
+#!/bin/bash
+# create boot image from program versions
+
+set -e
+
+#todo: documentation
+
+# Modify this list as needed.
+version_commands=(
+   "VBoxControl   --version" # virtualbox guest additions
+   "code          --version                       | head -1"
+   "git           --version | xargs | tr ' ' '\n' | tail -1"
+   "brave-browser --version | xargs | tr ' ' '\n' | tail -1"
+   "python3       --version | xargs | tr ' ' '\n' | tail -1"
+)
+
+# image settings: colors, sizes
+res=640x480
+bg=523
+fc=e53
+fs=28
+
+# build boot message
+message=""
+for ver_command in "${version_commands[@]}"; do
+   # newline
+   message+="|"
+   # program name
+   message+="$(echo $ver_command | awk '{print $1;}')"
+   # spaces
+   message+="++"
+   # program version
+   message+="$(eval $ver_command)"
+done
+
+# dummyimage.com can be used instead (or as fallback), but
+# it a) uses a slightly different url structure
+# and b) font-size is sensitive to long messages
+host=ipsumimage.appspot.com
+# for example, https://ipsumimage.appspot.com/640x480.png?s=28&b=523&f=e53&l=|VBoxControl++5.2.18r124319|code++1.42.0|git++2.17.1|brave-browser++79.1.2.42|python3++3.6.9
+remote_url="https://$host/$res.png?s=$fs&b=$bg&f=$fc&l=$message"
+target_path="$(dirname $(readlink -f $0))/../bootfiles/bootlogo.png"
+
+wgett -O "$target_path" "$remote_url" || curl -o "$target_path" "$remote_url"
+
+echo "complete"

--- a/tools/bootlogo.update
+++ b/tools/bootlogo.update
@@ -1,11 +1,12 @@
 #!/bin/bash
 # create boot image from program versions
-# for example, https://ipsumimage.appspot.com/640x480.png?s=28&b=523&f=e53&l=|VBoxControl++6.1.0r135406|code++1.42.0|git++2.17.1|brave-browser++79.1.2.42|python3++3.6.9
+# for example, https://ipsumimage.appspot.com/640x480.png?s=28&b=523&f=e53&l=|bash++4.4.20|VBoxControl++6.0.10r132072|code++1.43.1|git++2.17.1|brave-browser++80.1.5.113|python3++3.6.9
 
-set -e
+set -euo pipefail
 
 # Modify this list as needed.
 version_commands=(
+   "bash          --version | grep -Eo '[0-9]+.[0-9]+.[0-9]+'"
    "VBoxControl   --version" # virtualbox guest additions
    "code          --version                       | head -1"
    "git           --version | xargs | tr ' ' '\n' | tail -1"
@@ -13,23 +14,28 @@ version_commands=(
    "python3       --version | xargs | tr ' ' '\n' | tail -1"
 )
 
-# image settings: colors, sizes
-res=640x480
-bg=523
-fc=e53
-fs=28
+# image settings
+resolution=640x480
+background=523
+fontcolor=e53
+fontsize=28
 
 # build boot message
 message=""
 for ver_command in "${version_commands[@]}"; do
-   # pipes become newlines
-   message+="|"
    # program name
-   message+="$(echo $ver_command | awk '{print $1;}')"
-   # pluses become spaces 
-   message+="++"
-   # program version. eval allows additional pipeline commands
-   message+="$(eval $ver_command)"
+   program="$(echo $ver_command | awk '{print $1;}')"
+
+   if which $program > /dev/null; then
+      # pipes become newlines
+      message+="|"
+      # program name
+      message+="$program"
+      # pluses become spaces 
+      message+="++"
+      # program version. eval allows additional pipeline commands
+      message+="$(eval $ver_command)"
+   fi
 done
 
 # dummyimage.com can be used instead (or as fallback), but
@@ -37,7 +43,7 @@ done
 # and b) font-size is sensitive to long messages (whereas
 # ipsumimage let's you specify font size directly)
 host=ipsumimage.appspot.com
-remote_url="https://$host/$res.png?s=$fs&b=$bg&f=$fc&l=$message"
+remote_url="https://$host/$resolution.png?s=$fontsize&b=$background&f=$fontcolor&l=$message"
 target_path="$(dirname $(readlink -f $0))/../bootfiles/bootlogo.png"
 
 echo "downloading $remote_url"

--- a/tools/bootlogo.update
+++ b/tools/bootlogo.update
@@ -1,9 +1,8 @@
 #!/bin/bash
 # create boot image from program versions
+# for example, https://ipsumimage.appspot.com/640x480.png?s=28&b=523&f=e53&l=|VBoxControl++6.1.0r135406|code++1.42.0|git++2.17.1|brave-browser++79.1.2.42|python3++3.6.9
 
 set -e
-
-#todo: documentation
 
 # Modify this list as needed.
 version_commands=(
@@ -23,24 +22,25 @@ fs=28
 # build boot message
 message=""
 for ver_command in "${version_commands[@]}"; do
-   # newline
+   # pipes become newlines
    message+="|"
    # program name
    message+="$(echo $ver_command | awk '{print $1;}')"
-   # spaces
+   # pluses become spaces 
    message+="++"
-   # program version
+   # program version. eval allows additional pipeline commands
    message+="$(eval $ver_command)"
 done
 
 # dummyimage.com can be used instead (or as fallback), but
 # it a) uses a slightly different url structure
-# and b) font-size is sensitive to long messages
+# and b) font-size is sensitive to long messages (whereas
+# ipsumimage let's you specify font size directly)
 host=ipsumimage.appspot.com
-# for example, https://ipsumimage.appspot.com/640x480.png?s=28&b=523&f=e53&l=|VBoxControl++5.2.18r124319|code++1.42.0|git++2.17.1|brave-browser++79.1.2.42|python3++3.6.9
 remote_url="https://$host/$res.png?s=$fs&b=$bg&f=$fc&l=$message"
 target_path="$(dirname $(readlink -f $0))/../bootfiles/bootlogo.png"
 
-wgett -O "$target_path" "$remote_url" || curl -o "$target_path" "$remote_url"
+echo "downloading $remote_url"
+wget -O "$target_path" "$remote_url" || curl -o "$target_path" "$remote_url"
 
 echo "complete"

--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -21,6 +21,7 @@ read DIR
 
 if ! apt-get --yes build-dep syslinux; then
    echo "the most common cause of build-dep failures can be solved by following the steps described here: https://askubuntu.com/questions/496549/error-you-must-put-some-source-uris-in-your-sources-list"
+   exit 1
 fi
 mkdir -m 0777 /tmp/syslinux
 cd /tmp/syslinux

--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -11,9 +11,9 @@ set -e
 CWD=$(pwd)
 
 echo
-echo "--------------------------------------"
-echo "Add directory to isolinux search paths"
-echo -n "(for example /slax/boot): "
+echo "--------------------------------------------------------------------"
+echo "Add directory to isolinux search paths (usually /\$LIVEKITNAME/boot)"
+echo -n "(for example /slax/boot or /linux/boot): "
 read DIR
 
 
@@ -23,7 +23,7 @@ apt-get --yes build-dep syslinux
 mkdir -m 0777 /tmp/syslinux
 cd /tmp/syslinux
 apt-get source syslinux
-apt-get install upx
+apt-get --yes install upx
 cd syslinux*/core
 
 for file in fs/iso9660/iso9660.c fs/lib/loadconfig.c elflink/load_env32.c; do

--- a/tools/isolinux.bin.update
+++ b/tools/isolinux.bin.update
@@ -19,7 +19,9 @@ read DIR
 
 # download, unpack, and patch syslinux
 
-apt-get --yes build-dep syslinux
+if ! apt-get --yes build-dep syslinux; then
+   echo "the most common cause of build-dep failures can be solved by following the steps described here: https://askubuntu.com/questions/496549/error-you-must-put-some-source-uris-in-your-sources-list"
+fi
 mkdir -m 0777 /tmp/syslinux
 cd /tmp/syslinux
 apt-get source syslinux


### PR DESCRIPTION
I find it helpful to know what versions of the software I packaged with my iso. This optional script generates a bootlogo.png displaying packages and their corresponding versions.

Example boot image: https://ipsumimage.appspot.com/640x480.png?s=28&b=523&f=e53&l=|bash++4.4.20|VBoxControl++6.0.10r132072|code++1.43.1|git++2.17.1|brave-browser++80.1.5.113|python3++3.6.9

I also made small changes to ./tools/isolinux.bin.update

I'm looking forward to hearing your thoughts and hope you consider taking these changes. Thanks again for building a great tool!