### PR TITLE
Make PXE use basename for files fetched from PXEFILELIST

### DIFF
--- a/livekitlib
+++ b/livekitlib
@@ -492,7 +492,7 @@ download_data_pxe()
 
       if [ "$PROTOCOL" = "http" ]; then
          cat "$1/PXEFILELIST" | while read FILE; do
-            wget -O "$1/$LIVEKITNAME/$FILE" "http://$SERVER:$PORT/$FILE"
+            wget -O "$1/$LIVEKITNAME/$(basename $FILE)" "http://$SERVER:$PORT/$FILE"
          done
       else
          JOBS=3


### PR DESCRIPTION
Fixes issue where HTTP package download preserves file path to the
local filesystem, preventing download. Allows PXEFILELIST to present
multiple flie lists dependent on request arguments.

E.g. /v0.1/01-core.sb now downloads to
/memory/data/$LIVEKITNAME/01-core.sb 

instead of attempting to download to
/memory/data/$LIVEKITNAME/v0.1/01-core.sb

This may also be something that can be done with the TFTP download code. I don't use TFTP so don't have a test setup.