### PR TITLE
Enable log-file debug

### DIFF
--- a/livekitlib
+++ b/livekitlib
@@ -22,8 +22,8 @@ debug_log()
 {
    if [ "$DEBUG_IS_ENABLED" ]; then
       echo "- debug: $*" >&2
-      log "- debug: $*"
    fi
+   log "- debug: $*"
 }
 
 # header


### PR DESCRIPTION
When booting it's good to print the log debug only if debug is enabled. However, it will be interesting to store this debug log in a file everytime as it consumes very low space. This is interesting to check the boot process without debug enabled, bacause in some cases the debug option fails to complete the boot. This patch changes the default behaviour to always write in the log file.