### PR TITLE
genslaxiso debian10 missing iso

### DIFF
--- a/Slax/debian10/rootcopy/usr/bin/genslaxiso
+++ b/Slax/debian10/rootcopy/usr/bin/genslaxiso
@@ -34,6 +34,10 @@ if [ -e "$SOURCE/data/slax/boot/isolinux.bin" ]; then
    SLAX=$SOURCE/data/slax
 fi
 
+if [ -e "$SOURCE/iso/slax/boot/isolinux.bin" ]; then
+   SLAX=$SOURCE/iso/slax
+fi
+
 if [ -e "$SOURCE/toram/boot/isolinux.bin" ]; then
    SLAX=$SOURCE/toram
 fi


### PR DESCRIPTION
The debian10 version of the genslaxiso has missing the patch to search in ISO directory.