### PR TITLE
ssh.service: set correct file access

### DIFF
--- a/Slax/debian10/rootcopy/usr/lib/systemd/system/ssh.service
+++ b/Slax/debian10/rootcopy/usr/lib/systemd/system/ssh.service
@@ -5,7 +5,7 @@ ConditionPathExists=!/etc/ssh/sshd_not_to_be_run
 
 [Service]
 EnvironmentFile=-/etc/default/ssh
-ExecStartPre=-/bin/sh -c 'if ! ls /etc/ssh/ssh_host_* >/dev/null 2>&1; then /usr/sbin/dpkg-reconfigure openssh-server; fi'
+ExecStartPre=-/bin/sh -c 'if ! ls /etc/ssh/ssh_host_* >/dev/null 2>&1; then /usr/sbin/dpkg-reconfigure openssh-server; fi; chmod 600 /etc/ssh/ssh_host_*_key; chmod 644 /etc/ssh/ssh_host_*_key.pub'
 ExecStart=/usr/sbin/sshd -D $SSHD_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
When the SSH key files comes from rootcopy dir the file access are incorrect. So it will be desirable to set the correct file access level (based on defaults) before starting the SSH service. Without this patch it's impossible to add some user custom keys to the rootcopy from a readonly storage (for example an ISO image). This fixes the problem.