### PR TITLE
Use windows key to run xlunch

### DIFF
--- a/Slax/debian11/modules/03-desktop/rootcopy/root/.fluxbox/keys
+++ b/Slax/debian11/modules/03-desktop/rootcopy/root/.fluxbox/keys
@@ -137,3 +137,4 @@ Control Mod4 F11 :TakeToWorkspace 11
 Control Mod4 F12 :TakeToWorkspace 12
 
 Print :Exec fbprintscreen
+Super_L :Exec fbappselect


### PR DESCRIPTION
I have found a way to make win key to launch xlunch