### PR TITLE
Make user know if he/she has entered an alien command

### DIFF
--- a/Slax/debian11/rootcopy/usr/bin/slax
+++ b/Slax/debian11/rootcopy/usr/bin/slax
@@ -176,3 +176,9 @@ if [ "$1" = "savechanges" ]; then
    shift
    savechanges "$@"
 fi
+
+if [[ "$1" != "" || "activate" || "deactivate" || "list" || "savechanges" ]]; then
+   echo "The command ""$1"" doesn't exist, please refer to the following info:"
+   usage
+   exit
+fi


### PR DESCRIPTION
Hello Tomas,
I found, that while using slax(command) if I enter a command like:
`slax mount 01-core.sb`
then nothing is printed and for new users it can be confusing, hence I have made some changes so if he/she uses an alien command, then he will be treated with the usage.