### PR TITLE
Update livekitlib

### DIFF
--- a/livekitlib
+++ b/livekitlib
@@ -784,6 +784,7 @@ filter_noload()
 {
    local FILTER
    FILTER=$(cmdline_value noload)
+   FILTER=${FILTER//,/|}
    if [ "$FILTER" = "" ]; then
       cat -
    else


### PR DESCRIPTION
Separator "|" conflicts with grub2. We can use the "," delimiter in grub2 instead.