### PR TITLE
Update initramfs_create

### DIFF
--- a/initramfs/initramfs_create
+++ b/initramfs/initramfs_create
@@ -51,6 +51,8 @@ cp static/mount.dynfilefs $INITRAMFS/bin/@mount.dynfilefs
 cp static/mount.httpfs2 $INITRAMFS/bin/@mount.httpfs2
 cp static/blkid $INITRAMFS/bin
 chmod a+x $INITRAMFS/bin/*
+mkdir -p $INITRAMFS/etc/modprobe.d
+echo "options loop max_loop=32" >$INITRAMFS/etc/modprobe.d/local-loop.conf
 
 $INITRAMFS/bin/busybox | grep , | grep -v Copyright | tr "," " " | while read LINE; do
    for TOOL in $LINE; do


### PR DESCRIPTION
It seems that in Debian 12 the default number of loops in initrd is too low. This prevents modules from being mounted if their number is higher than 8.