### PR TITLE
Update connman-gtk-start

### DIFF
--- a/Slax/debian12/modules/04-apps/rootcopy/usr/bin/connman-gtk-start
+++ b/Slax/debian12/modules/04-apps/rootcopy/usr/bin/connman-gtk-start
@@ -6,7 +6,7 @@ if pgrep -x connman-gtk; then
       wmctrl -a "Network Settings"
       fbstartupnotify false
    else
-      gtkdialog -t "Already running" -m "The Network Manager is already running.
+      gtkdialog -t "Already running" -m "The Network Manager is already running."
 To access its window, double-click the icon that resembles two
 computers, located at the bottom right corner of the screen" -y OK
    fi


### PR DESCRIPTION
quotes omitted after `-m "The Network Manager is already running.`