### PR TITLE
Extension of functionality of filters load, noload

### DIFF
--- a/livekitlib
+++ b/livekitlib
@@ -899,8 +899,23 @@ copy_to_ram()
 #
 filter_load()
 {
-   local FILTER
+   local FILTER NUM START END
    FILTER=$(cmdline_value load)
+   FILTER=${FILTER//,/|}
+   if [ "$FILTER" != "" ]; then
+      # Добавьте этот код для обработки диапазона
+      if echo $FILTER | grep -qE '^[0-9]+-[0-9]+$'; then
+         START=$(echo $FILTER | cut -d '-' -f 1)
+         END=$(echo $FILTER | cut -d '-' -f 2)
+         FILTER=""
+         while [ $START -le $END ]; do
+            NUM=$(printf "%02d" $START)
+            FILTER="$FILTER|$NUM"
+            START=$(($START + 1))
+         done
+         FILTER=${FILTER#|}
+      fi
+   fi
    if [ "$FILTER" = "" ]; then
       cat -
    else
@@ -908,14 +923,26 @@ filter_load()
    fi
 }
 
-
 # noload filter
 #
 filter_noload()
 {
-   local FILTER
+   local FILTER NUM START END
    FILTER=$(cmdline_value noload)
    FILTER=${FILTER//,/|}
+   if [ "$FILTER" != "" ]; then
+      if echo $FILTER | grep -qE '^[0-9]+-[0-9]+$'; then
+         START=$(echo $FILTER | cut -d '-' -f 1)
+         END=$(echo $FILTER | cut -d '-' -f 2)
+         FILTER=""
+         while [ $START -le $END ]; do
+            NUM=$(printf "%02d" $START)
+            FILTER="$FILTER|$NUM"
+            START=$(($START + 1))
+         done
+         FILTER=${FILTER#|}
+      fi
+   fi
    if [ "$FILTER" = "" ]; then
       cat -
    else


### PR DESCRIPTION
The following formats for specifying the filter value are supported: `noload=03|04|05`, `noload=desktop|apps|chromium`
For compatibility with grub2, which does not allow the | character in kernel parameters: `noload=03,04,05`, `noload=desktop,apps,chromium`
The load and noload filters can also be specified as a range: `noload=03-05`