### PR TITLE
Update initramfs_create with zstd for *.zst kernel modules

### DIFF
--- a/initramfs/initramfs_create
+++ b/initramfs/initramfs_create
@@ -137,6 +137,7 @@ copy_including_deps /usr/share/terminfo/l/linux
 
 find $INITRAMFS -name "*.ko.gz" -exec gunzip {} \;
 find $INITRAMFS -name "*.ko.xz" -exec xz -d {} \;
+find $INITRAMFS -name "*.zst" -exec zstd -d --rm {} \;
 
 # trim modules.order file. Perhaps we could remove it entirely
 MODULEORDER="$(cd "$INITRAMFS/$LMK/"; find -name "*.ko" | sed -r "s:^./::g" | tr "\n" "|" | sed -r "s:[.]:.:g")"


### PR DESCRIPTION
This is used in ubuntu 24.04 and my local arch installation as far as I can tell

zstd by default keeps the compressed files. 
I had to specify the --rm so it gets rid of them.
Otherwise the kernel loading in initramfs breaks.