### PR TITLE
Add VirtIO modules to the initramfs for QEMU VM

### DIFF
--- a/initramfs/initramfs_create
+++ b/initramfs/initramfs_create
@@ -13,7 +13,7 @@ INITRAMFS=/tmp/$LIVEKITNAME-initramfs-$$
 copy_including_deps()
 {
    # if source doesn't exist or target exists, do nothing
-   if [ ! -e "$1" -o -e "$INITRAMFS"/"$1" ]; then
+   if [ ! -e "$1" ] || [ -f "$1" -a -e "$INITRAMFS"/"$1" ]; then
       return
    fi
 

--- a/initramfs/initramfs_create
+++ b/initramfs/initramfs_create
@@ -100,6 +100,7 @@ done
 copy_including_deps /$LMK/kernel/drivers/staging/zsmalloc # needed by zram
 copy_including_deps /$LMK/kernel/drivers/block/zram
 copy_including_deps /$LMK/kernel/drivers/block/loop.*
+copy_including_deps /$LMK/kernel/drivers/block/virtio_blk.*
 
 # usb drivers
 copy_including_deps /$LMK/kernel/drivers/usb/storage
@@ -120,6 +121,7 @@ copy_including_deps /$LMK/kernel/drivers/scsi/sg.*
 copy_including_deps /$LMK/kernel/drivers/ata
 copy_including_deps /$LMK/kernel/drivers/nvme
 copy_including_deps /$LMK/kernel/drivers/mmc
+copy_including_deps /$LMK/kernel/drivers/virtio
 
 # network support drivers
 if [ "$NETWORK" = "true" ]; then


### PR DESCRIPTION
Add necessary modules for the QEMU VM use case

In a QEMU VM use case, the block device for the rootfs is most probably based on virtio, so we need to include these necessary virtio modules to load root device