### PR TITLE
Extract the .zst kernal modules

### DIFF
--- a/initramfs/initramfs_create
+++ b/initramfs/initramfs_create
@@ -135,8 +135,9 @@ copy_including_deps /$LMK/modules.*
 copy_including_deps /usr/share/terminfo/l/linux
 
 
-find $INITRAMFS -name "*.ko.gz" -exec gunzip {} \;
-find $INITRAMFS -name "*.ko.xz" -exec xz -d {} \;
+find $INITRAMFS \(   -name '*.gz'  -exec gunzip {} \; \
+                  -o -name '*.xz'  -exec unxz {} \; \
+                  -o -name '*.zst' -exec unzstd --rm {} \; \)
 
 # trim modules.order file. Perhaps we could remove it entirely
 MODULEORDER="$(cd "$INITRAMFS/$LMK/"; find -name "*.ko" | sed -r "s:^./::g" | tr "\n" "|" | sed -r "s:[.]:.:g")"


### PR DESCRIPTION
the latest Ubuntu use .zst compressed kernel modules, but the modprobe in busybox doesn't support this, so extract them first